### PR TITLE
Follow symlinks in unprefixify()

### DIFF
--- a/ecleankernel/process.py
+++ b/ecleankernel/process.py
@@ -97,6 +97,7 @@ def get_removal_list(kernels: typing.List[Kernel],
             def unprefixify(filenames: typing.Iterable[str]
                             ) -> typing.Iterable[str]:
                 for fn in filenames:
+                    fn = os.path.realpath(fn)
                     if not os.path.exists(fn):
                         print(f'Note: referenced kernel does not '
                               f'exist: {fn}')


### PR DESCRIPTION
This allows eclean-kernel to correctly identify the kernels used by the bootloader config in the following scenario:

1. LILO says `image=/boot/vmlinuz`
2. `/boot/vmlinuz` is a symlink to `/boot/vmlinuz-X.Y.Z-suffix`, which is the actual kernel.

Before this commit, eclean-kernel -ap woulc complain that

    Note: strangely named used kernel: /boot/vmlinuz

and then list `vmlinuz-X.Y.Z-suffix` as one of the kernels to be removed.

Note: This does affect my system, where the actual `lilo.conf` is something like this:

```
image=/boot/vmlinuz
        label=default
        read-write
        root=/dev/sda1
        append="net.ifnames=0 init=/sbin/openrc-init sysrq_always_enabled=1"
```

and new kernels are installed through `installkernel` which comes from `installkernel-gentoo`, which produces the following `/boot/`:

```
-rw-r--r-- 1 root root     512 Jan  3  2022 boot.0800
lrwxrwxrwx 1 root root      18 Aug 13 11:49 config -> config-6.4.10-test
-rw-r--r-- 1 root root  109325 Aug 13 11:49 config-6.4.10-test
-rw-r--r-- 1 root root  109248 Jul 26 15:07 config-6.4.6-test
-rw-r--r-- 1 root root  109229 Aug  1 13:30 config-6.4.7-test
-rw-r--r-- 1 root root  109229 Aug  4 08:24 config-6.4.8-test
-rw-r--r-- 1 root root  109324 Aug 10 16:45 config-6.4.9-test
lrwxrwxrwx 1 root root      17 Aug 10 16:45 config.old -> config-6.4.9-test
-rw-r--r-- 1 root root       0 Jan  2  2022 .keep
-rw------- 1 root root   23040 Aug 13 11:49 map
lrwxrwxrwx 1 root root      22 Aug 13 11:49 System.map -> System.map-6.4.10-test
-rw-r--r-- 1 root root 4288104 Aug 13 11:49 System.map-6.4.10-test
-rw-r--r-- 1 root root 4286315 Jul 26 15:07 System.map-6.4.6-test
-rw-r--r-- 1 root root 4286495 Aug  1 13:30 System.map-6.4.7-test
-rw-r--r-- 1 root root 4286603 Aug  4 08:24 System.map-6.4.8-test
-rw-r--r-- 1 root root 4287870 Aug 10 16:45 System.map-6.4.9-test
lrwxrwxrwx 1 root root      21 Aug 10 16:45 System.map.old -> System.map-6.4.9-test
lrwxrwxrwx 1 root root      19 Aug 13 11:49 vmlinuz -> vmlinuz-6.4.10-test
-rw-r--r-- 1 root root 7913168 Aug 13 11:49 vmlinuz-6.4.10-test
-rw-r--r-- 1 root root 7908880 Jul 26 15:07 vmlinuz-6.4.6-test
-rw-r--r-- 1 root root 7908176 Aug  1 13:30 vmlinuz-6.4.7-test
-rw-r--r-- 1 root root 7909136 Aug  4 08:24 vmlinuz-6.4.8-test
-rw-r--r-- 1 root root 7911952 Aug 10 16:45 vmlinuz-6.4.9-test
lrwxrwxrwx 1 root root      18 Aug 10 16:45 vmlinuz.old -> vmlinuz-6.4.9-test
```