### PR TITLE
Use samefile() instead of regex matching when checking bootloader kernel paths

### DIFF
--- a/ecleankernel/process.py
+++ b/ecleankernel/process.py
@@ -12,7 +12,7 @@ import typing
 from pathlib import Path
 
 from ecleankernel.bootloader import Bootloader
-from ecleankernel.file import KernelImage
+from ecleankernel.file import GenericFile, KernelImage
 from ecleankernel.kernel import Kernel
 from ecleankernel.sort import KernelSort
 
@@ -89,26 +89,7 @@ def get_removal_list(kernels: typing.List[Kernel],
                 raise SystemError(f'Unable to get kernels from'
                                   f' bootloader config ({bootloader})')
 
-            used_paths = bootloader()
-
-            prefix = re.compile(r'^/boot/(vmlinu[xz]|kernel|bzImage)-')
-            ignored = re.compile(r'^/boot/xen')
-
-            def unprefixify(filenames: typing.Iterable[str]
-                            ) -> typing.Iterable[str]:
-                for fn in filenames:
-                    if not os.path.exists(fn):
-                        print(f'Note: referenced kernel does not '
-                              f'exist: {fn}')
-                    else:
-                        kv, numsubs = prefix.subn('', fn)
-                        if numsubs == 1:
-                            yield kv
-                        elif not ignored.match(fn):
-                            print(f'Note: strangely named used kernel: '
-                                  f'{fn}')
-
-            used = frozenset(unprefixify(used_paths))
+            used_paths = frozenset(p for p in bootloader() if os.path.exists(p))
 
         if limit is not None:
             ordered = sorted(
@@ -120,9 +101,16 @@ def get_removal_list(kernels: typing.List[Kernel],
             candidates = kernels
 
         for k in candidates:
+            def kernel_in_use(kernel_images: typing.List[GenericFile],
+                              bootloader_used_kernels: typing.Iterable[str]
+                             ) -> bool:
+                return any(os.path.samefile(kernel_image.path, bp)
+                           for bp in bootloader_used_kernels
+                           for kernel_image in kernel_images)
+
             if destructive:
                 remove_kernels.setdefault(k, []).append('unwanted')
-            elif k.version not in used:
+            elif not kernel_in_use(k.all_files, used_paths):
                 assert bootloader is not None
                 remove_kernels.setdefault(k, []).append(
                     f'not referenced by bootloader ({bootloader.name})')

--- a/ecleankernel/process.py
+++ b/ecleankernel/process.py
@@ -6,7 +6,6 @@ import itertools
 import logging
 import os
 import os.path
-import re
 import typing
 
 from pathlib import Path
@@ -89,7 +88,8 @@ def get_removal_list(kernels: typing.List[Kernel],
                 raise SystemError(f'Unable to get kernels from'
                                   f' bootloader config ({bootloader})')
 
-            used_paths = frozenset(p for p in bootloader() if os.path.exists(p))
+            used_paths = frozenset(p for p in bootloader()
+                                   if os.path.exists(p))
 
         if limit is not None:
             ordered = sorted(
@@ -102,9 +102,9 @@ def get_removal_list(kernels: typing.List[Kernel],
 
         for k in candidates:
             def kernel_in_use(kernel_images: typing.List[GenericFile],
-                              bootloader_used_kernels: typing.Iterable[str]
-                             ) -> bool:
-                return any(os.path.samefile(kernel_image.path, bp)
+                              bootloader_used_kernels: typing.Iterable[str],
+                              ) -> bool:
+                return any(kernel_image.path.samefile(bp)
                            for bp in bootloader_used_kernels
                            for kernel_image in kernel_images)
 

--- a/test/test_process.py
+++ b/test/test_process.py
@@ -122,10 +122,10 @@ class KernelRemovalTests(unittest.TestCase):
         td = Path(self.td.name)
 
         class MockBootloader(Bootloader):
-            name = 'mock'
+            name = "mock"
 
             def __call__(self) -> typing.Iterable[str]:
-                yield str(td / 'symlink')
+                yield str(td / "symlink")
 
         self.assertEqual(
             get_removal_list(self.kernels,
@@ -133,11 +133,11 @@ class KernelRemovalTests(unittest.TestCase):
                              limit=None,
                              destructive=False,
                              bootloader=MockBootloader()),
-            {self.kernels[2]: ['vmlinuz does not exist',
-                               'not referenced by bootloader (mock)'],
-             self.kernels[3]: ['vmlinuz does not exist',
-                               'not referenced by bootloader (mock)'],
-             self.kernels[1]: ['not referenced by bootloader (mock)'],
+            {self.kernels[2]: ["vmlinuz does not exist",
+                               "not referenced by bootloader (mock)"],
+             self.kernels[3]: ["vmlinuz does not exist",
+                               "not referenced by bootloader (mock)"],
+             self.kernels[1]: ["not referenced by bootloader (mock)"],
              })
 
     @unittest.expectedFailure


### PR DESCRIPTION
This allows eclean-kernel to correctly identify the kernels used by the bootloader config in the following scenario:

1. LILO says `image=/boot/vmlinuz`
2. `/boot/vmlinuz` is a symlink to `/boot/vmlinuz-X.Y.Z-suffix`, which is the actual kernel.

Before this commit, eclean-kernel -ap woulc complain that

    Note: strangely named used kernel: /boot/vmlinuz

and then list `vmlinuz-X.Y.Z-suffix` as one of the kernels to be removed.

Closes #42 