### PR TITLE
layout/blspec.py: also clean-up UKI's with 'gentoo' prefix

### DIFF
--- a/ecleankernel/layout/blspec.py
+++ b/ecleankernel/layout/blspec.py
@@ -128,12 +128,16 @@ class BlSpecLayout(ModuleDirLayout):
         # collect from ESP/Linux
         if self.ukidir.is_dir():
             for file in os.listdir(self.ukidir):
-                if (not file.startswith(self.kernel_id) or
-                        not file.endswith(".efi")):
-                    # This file is not an efi file or does not belong to us
+                if not file.endswith(".efi"):
+                    # Not an UKI
                     continue
-                ver = file.removeprefix(self.kernel_id +
-                                        "-").removesuffix(".efi")
+
+                ver = file.removeprefix(f"{self.kernel_id}-"
+                                        ).removeprefix("gentoo-")
+                if file == ver:
+                    # Not our UKI
+                    continue
+                ver = ver.removesuffix(".efi")
 
                 kernels[(ver, "uki")] = self.append_kernel_files(
                         KernelFileType.KERNEL,


### PR DESCRIPTION
With version 8 installkernel-gentoo gains an optional plugin to install UKIs to the usual location at `${ESP}/EFI/Linux` (i.e. BLS type 2 layout). This is useful for boot loaders such as systemd-boot that auto discover UKIs at this location, as well as for EFI stub booting where it is required to have the UKI on the ESP (which is not necessarily mounted at /boot).

Because the entry-token that is the usual prefix for these UKIs is specific to systemd and `kernel-install` (i.e. installkernel-systemd), installkernel-gentoo prefixes the UKIs with '`gentoo`' instead. The changes here ensure that eclean-kernel recognizes these UKIs as ours and cleans them up as well.