### PR TITLE
bootloader: consider GRUB_CFG as location for grub config

### DIFF
--- a/ecleankernel/bootloader/grub.py
+++ b/ecleankernel/bootloader/grub.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import logging
+import os
 import os.path
 import typing
 
@@ -11,7 +12,10 @@ from ecleankernel.bootloader.lilo import LILO
 class GRUB(LILO):
     name = 'grub'
     kernel_re = r'^\s*(kernel|module)\s*(\([^)]+\))?(?P<path>\S+)'
-    def_path = ('/boot/grub/menu.lst', '/boot/grub/grub.conf')
+    def_path = (os.environ.get("GRUB_CFG"),
+                '/boot/grub/menu.lst',
+                '/boot/grub/grub.conf',
+                )
 
     def _get_kernels(self,
                      content: str

--- a/ecleankernel/bootloader/grub2.py
+++ b/ecleankernel/bootloader/grub2.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 import logging
+import os
 import subprocess
 import typing
 
@@ -17,7 +18,10 @@ grub2_autogen_header = '''#
 class GRUB2(GRUB):
     name = 'grub2'
     kernel_re = r'^\s*linux\s*(\([^)]+\))?(?P<path>\S+)'
-    def_path = ('/boot/grub/grub.cfg', '/boot/grub2/grub.cfg')
+    def_path = (os.environ.get("GRUB_CFG"),
+                '/boot/grub/grub.cfg',
+                '/boot/grub2/grub.cfg',
+                )
 
     def __init__(self) -> None:
         super().__init__()

--- a/ecleankernel/bootloader/lilo.py
+++ b/ecleankernel/bootloader/lilo.py
@@ -11,7 +11,7 @@ from ecleankernel.bootloader import Bootloader, BootloaderNotFound
 class LILO(Bootloader):
     name = 'lilo'
     kernel_re = r'^\s*image\s*=\s*(?P<path>.+)\s*$'
-    def_path: typing.Tuple[str, ...] = ('/etc/lilo.conf',)
+    def_path: typing.Tuple[typing.Optional[str], ...] = ('/etc/lilo.conf',)
 
     def __init__(self,
                  path: typing.Optional[str] = None
@@ -23,6 +23,8 @@ class LILO(Bootloader):
             paths = (paths,)
 
         for p in paths:
+            if p is None:
+                continue
             try:
                 with open(p) as f:
                     logging.debug(f'{p} found')


### PR DESCRIPTION
`sys-kernel/installkernel[grub]` supports setting `GRUB_CFG` in the environment to update a `grub.cfg` in a non-standard location. Specifically this is useful with `sys-boot/grub[secureboot]` where the built grub efi executable loads the `grub.cfg` from the same directory it is in.

Recognize the same environment variable here so we don't accidentally update the wrong config.